### PR TITLE
Use SPIP site logo

### DIFF
--- a/sq-unepage/noisettes/menu_haut.html
+++ b/sq-unepage/noisettes/menu_haut.html
@@ -8,8 +8,8 @@
     <li class="double bloc1">
         <a href="[(#URL_SITE_SPIP)]" title="Accueil"><span class="logo">[(#CHEMIN{img/pictos_blc/[(#NOM_SITE_SPIP)].png}|image_reduire{100})]</span>[(#NOM_SITE_SPIP)]</a>
     </li>
-    <li class="double bloc2">
-        <a href="[(#CONFIG{th/site_ent_url}|sinon{http://www.laclasse.com})]" target="_blank" title="[(#CONFIG{th/site_ent_nom}|sinon{.laclasse.com})]">[(#CONFIG{th/site_ent_nom}|sinon{laclasse.com})]</a>
+    <li class="double bloc1">
+      #LOGO_SITE_SPIP
     </li>
   </div>
 	


### PR DESCRIPTION
La contribution contient 2 commits :

- Ajout d'un fichier vide générant une erreur sur le squelette lors de l'accès au site depuis le backend spip
- Utilisation du logo du site SPIP configurable dans la rubrique <identité du site> dans le menu_haut côté frontend